### PR TITLE
Update get_rds_slow_log

### DIFF
--- a/get_rds_slow_log
+++ b/get_rds_slow_log
@@ -36,7 +36,8 @@ cd $SLOW_HOME
 mkdir -p $SLOW_HOME/$TODAY
 
 function downloadSlowLog () {
-  aws rds download-db-log-file-portion --output text --db-instance-identifier $INSTANCE_ID --log-file-name $1
+  export AWS_MAX_ATTEMPTS=100
+  aws rds download-db-log-file-portion --output text --db-instance-identifier $INSTANCE_ID --log-file-name $1 --starting-token 0
 }
 
 echo "Downloading slow logs for $TODAY";


### PR DESCRIPTION
increase AWS_MAX_ATTEMPTS to avoid the following error: An error occurred (Throttling) when calling the DownloadDBLogFilePortion operation (reached max retries: 2): Rate exceeded